### PR TITLE
Add options --limit and --offset to Shodan queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is an example of shodan wave running, the password was not found through ra
 [![asciicast](https://asciinema.org/a/G7gVOiReMiv43V8wlMbB4mm9B.png)](https://asciinema.org/a/G7gVOiReMiv43V8wlMbB4mm9B?autoplay=1)
 
 ### How to use?
-To use shodan wave you need an api key you can get a free one at https://www.shodan.io/, then you need to follow the following steps.
+To use shodanwave you need an api key which you can get for free at https://www.shodan.io/, then you need to follow the next steps.
 
 ### Installation
 
@@ -50,10 +50,16 @@ optional arguments:
                         Select your passwords wordlist
   -k ADDRESS, --shodan ADDRESS
                         Shodan API key
+  -l LIMIT, --limit LIMIT
+                        Limit the number of registers responsed by Shodan
+  -o OFFSET, --offset OFFSET
+                        Shodan skips this number of registers from response
+
 
 ```
 ### Attention
 Use this tool wisely and not for evil. To get the best performece of this tool you need to pay for shodan to get full API access
+Options --limit and --offset may need a paying API key and consume query credits from your Shodan account.
 
 ### References:
 

--- a/shodanwave.py
+++ b/shodanwave.py
@@ -43,6 +43,9 @@ def main() :
  parser.add_argument('-u','--username', dest="username",  type=file, help='Select your usernames wordlist')
  parser.add_argument('-w','--wordlist', dest="password",  type=file, help='Select your passwords wordlist')
  parser.add_argument('-k','--shodan', dest="address", default='', type=str, help='Shodan API key')
+ parser.add_argument('-l','--limit', dest="limit", default='100', type=str, help='Limit the number of registers responsed by Shodan')
+ parser.add_argument('-o','--offset', dest="offset", default='1', type=str, help='Shodan skips this number of registers from response')
+
  args = parser.parse_args()
 
 
@@ -92,7 +95,7 @@ def main() :
   try:
 
    shodanapi = shodan.Shodan(args.address)
-   api = shodanapi.search(args.search)
+   api = shodanapi.search(args.search, limit = args.limit, offset = args.offset)
    total = api.get('total')
 
    usernames = args.username.readlines()


### PR DESCRIPTION
Add an option so a limit of results can be set (default is as it was: 100).
Add another option so a number of results is skiped in Shodan result.

This options may need a payed account to shodan as they both consume query credits.